### PR TITLE
#12 bugfix: limit fps to 30

### DIFF
--- a/Bunnies&Badgers.py
+++ b/Bunnies&Badgers.py
@@ -48,6 +48,9 @@ def main():
     timestart = pygame.time.get_ticks()
     pygame.mixer.music.play(-1, 0.0)
     num_arrows = 100
+    # for fps control
+    FPS = 30
+    clock = pygame.time.Clock()
 
     running = 1
     exitcode = 0
@@ -185,6 +188,8 @@ def main():
             accuracy=round(acc[0]*1.0/acc[1]*100,2)
         else:
             accuracy=0
+        # limit the Loop to the FPS
+        clock.tick(FPS)
     # 11 - Win/lose display        
     pygame.font.init()
     font = pygame.font.Font(None, 24)


### PR DESCRIPTION
I have used the ```pygame.time.Clock().tick()``` function to limit the frame rate of the game to 30. This way the game would be the same speed regardless of the system it is being run on.